### PR TITLE
修复测试点详情转义问题

### DIFF
--- a/web/js/app.js
+++ b/web/js/app.js
@@ -31,6 +31,15 @@ var OJ_VERDICT_COLOR = new Array(
     "text-danger",  // SE
     "text-danger"
 );
+
+function HTMLEncode(html) {
+  var temp = document.createElement("div");
+  (temp.textContent != null) ? (temp.textContent = html) : (temp.innerText = html);
+  var output = temp.innerHTML;
+  temp = null;
+  return output;
+}
+
 function testHtml(id, caseJsonObject)
 {
   return '<div class="panel panel-default test-for-popup"> \
@@ -52,16 +61,16 @@ function testHtml(id, caseJsonObject)
                 <div class="sample-test">\
                     <div class="input">\
                         <h4>输入</h4>\
-                        <pre>' + caseJsonObject.input + '</pre>\
+                        <pre>' + HTMLEncode(caseJsonObject.input) + '</pre>\
                     </div>\
                     <div class="output">\
                         <h4>输出</h4>\
-                        <pre>' + caseJsonObject.user_output + '</pre>\
+                        <pre>' + HTMLEncode(caseJsonObject.user_output) + '</pre>\
                     </div>\
                     <div class="output">\
                         <h4>答案</h4>\
-                        <pre>' + caseJsonObject.output + '</pre>\
-                    </div>' + (caseJsonObject.checker_log == "" ? "" :  '<div class="output"><h4>检查日志</h4><pre>' + caseJsonObject.checker_log + '</pre></div>')
+                        <pre>' + HTMLEncode(caseJsonObject.output) + '</pre>\
+                    </div>' + (caseJsonObject.checker_log == "" ? "" :  '<div class="output"><h4>检查日志</h4><pre>' + HTMLEncode(caseJsonObject.checker_log) + '</pre></div>')
       + '<div class="output">\
                         <h4>系统信息</h4>\
                         <pre>exit code: ' + caseJsonObject.exit_code + ', checker exit code: ' + caseJsonObject.checker_exit_code + '</pre>\


### PR DESCRIPTION
### 问题

评测信息页中，用户输出显示不正确。

### 复现方法

提交以下代码：

```cpp
#include <iostream>
int main()
{
    puts("a<b");
}
```

期望在网页测评信息页输出部分看到：

```
a<b
```

实际在网页看到的是：

```
a
```

在 A+B Problem 提交上述代码，评测机调试信息：

```
Main=Main.ccstatus = 0
init_call_counter:1
pid=231131 [Solution ID: 170] judging /srv/http/bootstrap4/scnuoj/judge/data/1000/0.in
{
        "subtasks":     [{
                        "cases":        [{
                                        "verdict":      6,
                                        "time": 0,
                                        "memory":       216,
                                        "exit_code":    0,
                                        "input":        "1 2",
                                        "output":       "3",
                                        "user_output":  "a<b",
                                        "checker_exit_code":    0,
                                        "checker_log":  ""
                                }],
                        "score":        0
                }]
}
[Solution ID: 170] Result = 6
tmp_pid = 231035
<<1 done!>>
```

### 说明

由于评测机调试信息显示的内容没啥问题，所以就怀疑是视图层的问题了。

我这个更改中的转码是在 json 转对象后进行，因此大概率也只是一个 dirty-hack。

如果能在 `var json = '$json';` 之前完成转码当然是最好的。