### PR TITLE
修复测试点详情转义问题

### DIFF
--- a/views/solution/detail.php
+++ b/views/solution/detail.php
@@ -107,6 +107,8 @@ $this->params['breadcrumbs'][] = $this->title;
     </div>
 <?php
 $json = $model->solutionInfo->run_info;
+$json = str_replace("<", "&lt;", $json);
+$json = str_replace(">", "&gt;", $json);
 $json = str_replace(PHP_EOL,"<br>",$json);
 $json = str_replace("\\n","<br>",$json);
 $json = str_replace("'","\'",$json);

--- a/views/solution/result.php
+++ b/views/solution/result.php
@@ -24,6 +24,8 @@ if (!$model->canViewErrorInfo()) {
         </div>
         <?php
         $json = $model->solutionInfo->run_info;
+        $json = str_replace("<", "&lt;", $json);
+        $json = str_replace(">", "&gt;", $json);
         $json = str_replace(PHP_EOL,"<br>",$json);
         $json = str_replace("\\n","<br>",$json);
         $json = str_replace("'","\'",$json);


### PR DESCRIPTION
### 问题

评测信息页中，用户输出显示不正确。

### 复现方法

提交以下代码：

```cpp
#include <iostream>
int main()
{
    puts("a<b");
}
```

期望在网页测评信息页输出部分看到：

```
a<b
```

实际在网页看到的是：

```
a
```

在 A+B Problem 提交上述代码，评测机调试信息：

```
Main=Main.ccstatus = 0
init_call_counter:1
pid=231131 [Solution ID: 170] judging /srv/http/bootstrap4/scnuoj/judge/data/1000/0.in
{
        "subtasks":     [{
                        "cases":        [{
                                        "verdict":      6,
                                        "time": 0,
                                        "memory":       216,
                                        "exit_code":    0,
                                        "input":        "1 2",
                                        "output":       "3",
                                        "user_output":  "a<b",
                                        "checker_exit_code":    0,
                                        "checker_log":  ""
                                }],
                        "score":        0
                }]
}
[Solution ID: 170] Result = 6
tmp_pid = 231035
<<1 done!>>
```

### 说明

由于评测机调试信息显示的内容没啥问题，所以就怀疑是视图层的问题了。

这里对 `<` 和 `>` 做了处理。