### PR TITLE
修复小组作业设置面包屑导航链接无效的问题

### DIFF
--- a/views/homework/update.php
+++ b/views/homework/update.php
@@ -14,7 +14,7 @@ use app\models\Homework;
 $this->title = Html::encode($model->title);
 $this->params['breadcrumbs'][] = ['label' => Yii::t('app', 'Group'), 'url' => ['index']];
 $this->params['breadcrumbs'][] = ['label' => Html::encode($model->group->name), 'url' => ['/group/view', 'id' => $model->group->id]];
-$this->params['breadcrumbs'][] = ['label' => Html::encode($model->title), 'url' => ['view', 'id' => $model->id]];
+$this->params['breadcrumbs'][] = ['label' => Html::encode($model->title), 'url' => ['/contest/view', 'id' => $model->id]];
 $this->params['breadcrumbs'][] = Yii::t('app', 'Setting');
 $this->params['model'] = $model;
 $problems = $model->problems;


### PR DESCRIPTION
## 问题

小组作业设置的面包屑导航中，标有作业名称的链接无效。

## 问题复现步骤

* 第一步：任意创建或进入一个已有的小组。
* 第二步：任意创建或进入一个已有的小组作业（比赛）。
* 第三步：点击大标题旁边的设置。
* 第四步：在设置页的面包屑导航栏找到标有小组作业的一项，点击。

期望：返回第二步打开的小组作业页面。
实际：跳转到 `/homework/view`，显示 404 页面不存在。

## 说明

Fix #97 