### PR TITLE
修复图片无法上传的问题

### DIFF
--- a/controllers/ImageController.php
+++ b/controllers/ImageController.php
@@ -8,7 +8,7 @@ use yii\web\ForbiddenHttpException;
 use app\components\Uploader;
 
 /**
- * 用来接收 CKeditor 编辑器上传的图片
+ * 用来接收 Editormd 编辑器上传的图片
  */
 class ImageController extends BaseController
 {
@@ -16,13 +16,13 @@ class ImageController extends BaseController
     public function actionUpload()
     {
         if (Yii::$app->request->isPost && !Yii::$app->user->isGuest) {
-            $up = new Uploader('upload');
+            $up = new Uploader('editormd-image-file');
             $info = $up->getFileInfo();
             if ($info['state'] == 'SUCCESS') {
                 $info['url'] = Yii::getAlias('@web') . '/' . $info['url'];
-                $info['uploaded'] = true;
+                $info['success'] = 1;
             } else {
-                $info['uploaded'] = false;
+                $info['success'] = 0;
             }
             echo json_encode($info);
         } else {

--- a/widgets/editormd/Editormd.php
+++ b/widgets/editormd/Editormd.php
@@ -42,7 +42,7 @@ class Editormd extends InputWidget
             'tex' => true,
             'flowChart' => true,
             'sequenceDiagram' => true,
-            'imageUploadURL' => Url::to(['img_upload']),
+            'imageUploadURL' => Url::to(['/image/upload']),
             'autoFocus' => false,
         ];
         $this->clientOptions = ArrayHelper::merge($this->_options, $this->clientOptions);


### PR DESCRIPTION
## 问题

Editormd 编辑器中的图片上传功能无法使用。

## 问题复现步骤

* 第一步：在任意 Editormd 编辑器（如编辑题目描述）点击【添加图片】按钮。
* 第二步：点击【本地上传】。
* 第三步：选择一张不超过 PHP 最大上传大小的图片。

期望：图片出现在 `web/uploads` 下，Editormd 显示 `/uploads/` 为前缀的图片地址，点击确认后成功插入图片。
实际：图片没有出现在 `web/uploads`，Editormd 图片地址一栏为空，图片没有上传成功。

## 说明

Fix #93 
