### PR TITLE
修复非法查看打印详情页时报内部错误的问题

### DIFF
--- a/controllers/PrintController.php
+++ b/controllers/PrintController.php
@@ -163,7 +163,7 @@ class PrintController extends BaseController
      */
     protected function findModel($id)
     {
-        if (($model = ContestPrint::findOne($id)) !== null || !Yii::$app->user->isGuest) {
+        if (($model = ContestPrint::findOne($id)) !== null && !Yii::$app->user->isGuest) {
             if ($model->user_id == Yii::$app->user->id || Yii::$app->user->identity->role == User::ROLE_ADMIN) {
                 return $model;
             }


### PR DESCRIPTION
## 问题

非法查看打印详情页时报内部错误，报错：

```
PHP Notice – yii\base\ErrorException
Trying to get property 'user_id' of non-object
```

## 复现

- 管理员或普通用户身份登录 OJ
- 访问一个不存在的打印详情页 /print/view?id=序号，其中序号为非法数字

期望：显示 404。
实际：内部错误。

## 说明

https://github.com/shi-yang/jnoj/blob/8fe96b68ce955fee97db02554f5cb3a74ae8574a/controllers/PrintController.php#L156-L174
考虑 `$model === null` 的情况，访问 `$model->user_id` 自然会报错（第 166-167 行）。