### PR TITLE
修复修改用户权限报内部错误的问题

### DIFF
--- a/modules/admin/controllers/UserController.php
+++ b/modules/admin/controllers/UserController.php
@@ -64,7 +64,7 @@ class UserController extends Controller
             return $this->refresh();
         }
 
-        if (Yii::$app->request->get('action')) {
+        if (Yii::$app->request->get('action') && Yii::$app->request->isPost) {
             $keys = Yii::$app->request->post('keylist');
             $action = Yii::$app->request->get('action');
             foreach ($keys as $key) {


### PR DESCRIPTION
## 问题 

在后台用户列表页面修改用户权限时报内部错误：

```
PHP Warning – yii\base\ErrorException
Invalid argument supplied for foreach()
```

## 复现

* 创建若干用户。
* 访问 `/admin/user/index` 页面。
* 勾选若干用户。
* 点击设为普通用户，或点击设为VIP用户。

期望：页面刷新；用户权限得到更改。
实际：提示内部错误，随后移除有关 GET 请求后强制刷新则恢复正常；用户权限得到更改。

## 说明

https://github.com/shi-yang/jnoj/blob/8fe96b68ce955fee97db02554f5cb3a74ae8574a/modules/admin/controllers/UserController.php#L67-L76

第一次执行这一段应该是不会报错的，但是后面来了个 `$this->refresh()`，这时就没有 POST 了，执行上面这一段就报错了。

> 可以与这一部分对比，这个是后台的问题列表页对应的内容，设置的是题目可见性：

https://github.com/shi-yang/jnoj/blob/8fe96b68ce955fee97db02554f5cb3a74ae8574a/modules/admin/controllers/ProblemController.php#L73-L98